### PR TITLE
chore: upgrade to pnpm 11.1.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-lockfile-v6=true
+minimumreleaseage=1440

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
     "@changesets/cli": "^2.25.2",
     "turbo": "^1.6.3"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - packages/*
   - tests/*
+allowBuilds:
+  turbo: true


### PR DESCRIPTION
## Summary

- Upgrade pnpm to `11.1.3`
- Add `minimumreleaseage=1440` to `.npmrc` — blocks packages published in the last 24h, reducing supply chain attack risk
- Remove obsolete `use-lockfile-v6` setting (default since pnpm 9)
- Approve native build scripts via `pnpm-workspace.yaml`

## Test plan
- [ ] CI passes